### PR TITLE
Add Bluesky block history to admin analytics

### DIFF
--- a/src/components/AnalyticsStudio.jsx
+++ b/src/components/AnalyticsStudio.jsx
@@ -533,6 +533,12 @@ function useAnalyticsArchive(agent, did) {
       runSync('resume');
       return;
     }
+    // Existing archives predate the blocks store. Populate the new timeline
+    // on their first visit even when the post archive itself is still fresh.
+    if (!data.meta.blocks) {
+      runSync('incremental');
+      return;
+    }
     if (Date.now() - (pm.syncedAt || 0) < AUTO_SYNC_AFTER_MS) return;
     runSync('incremental');
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/AnalyticsStudio.jsx
+++ b/src/components/AnalyticsStudio.jsx
@@ -59,6 +59,7 @@ import { atmosphereRowFromEntry, fetchRepoCar, readRepoCar } from '../lib/carRep
 import { holdReload } from '../lib/reloadHold.js';
 import {
   hydrateActors,
+  sweepBlocks,
   sweepFollowers,
   sweepInbound,
   sweepOutbound,
@@ -80,6 +81,7 @@ const EVENT_DEPTH_DAYS = 365;
 
 const TABS = [
   { key: 'followers', label: 'Followers' },
+  { key: 'blocks', label: 'Blocks' },
   { key: 'posts', label: 'Posts' },
   { key: 'engagement', label: 'Engagement' },
   { key: 'people', label: 'People' },
@@ -163,6 +165,7 @@ export default function AnalyticsStudio({ agent, did }) {
           </div>
 
           {tab === 'followers' && <FollowersTab archive={archive} period={period} nowMs={nowMs} />}
+          {tab === 'blocks' && <BlocksTab archive={archive} period={period} nowMs={nowMs} />}
           {tab === 'posts' && <PostsTab archive={archive} period={period} nowMs={nowMs} />}
           {tab === 'engagement' && (
             <EngagementTab archive={archive} period={period} kind={kind === 'mention' ? 'all' : kind} nowMs={nowMs} />
@@ -187,6 +190,7 @@ function useAnalyticsArchive(agent, did) {
     persistent: true,
     posts: [],
     followers: [],
+    blocks: [],
     inbound: [],
     outbound: [],
     atmosphere: [],
@@ -202,16 +206,18 @@ function useAnalyticsArchive(agent, did) {
   const attemptedActorsRef = useRef(new Set());
 
   async function reload(store) {
-    const [posts, followers, inbound, outbound, atmosphere, actorRows, pm, fm, im, om, rm] =
+    const [posts, followers, blocks, inbound, outbound, atmosphere, actorRows, pm, fm, bm, im, om, rm] =
       await Promise.all([
         store.all('posts'),
         store.all('followers'),
+        store.all('blocks'),
         store.all('inbound'),
         store.all('outbound'),
         store.all('atmosphere'),
         store.all('actors'),
         store.getMeta('posts'),
         store.getMeta('followers'),
+        store.getMeta('blocks'),
         store.getMeta('inbound'),
         store.getMeta('outbound'),
         store.getMeta('repo'),
@@ -222,13 +228,14 @@ function useAnalyticsArchive(agent, did) {
       persistent: store.persistent,
       posts,
       followers,
+      blocks,
       inbound,
       outbound,
       atmosphere,
-      meta: { posts: pm, followers: fm, inbound: im, outbound: om, repo: rm },
+      meta: { posts: pm, followers: fm, blocks: bm, inbound: im, outbound: om, repo: rm },
       rev: prev.rev + 1,
     }));
-    return { posts, meta: { posts: pm, inbound: im, outbound: om } };
+    return { posts, meta: { posts: pm, blocks: bm, inbound: im, outbound: om } };
   }
 
   useEffect(() => {
@@ -288,6 +295,25 @@ function useAnalyticsArchive(agent, did) {
         });
       } else if (fw.error) {
         errors.push(`followers: ${fw.error}`);
+      }
+      if (ac.signal.aborted) return;
+
+      /* Blocks received — Constellation enumerates block records in other
+         repos that point at this DID. Their rkeys are TIDs, giving the same
+         reconstructed timeline the follower graph uses. Replace only after
+         a complete sweep so a failed request cannot erase good data. */
+      progress('blocks');
+      const bw = await sweepBlocks(did, { signal: ac.signal, onProgress: tick });
+      if (bw.complete) {
+        await store.clear('blocks');
+        await store.putAll('blocks', bw.blocks);
+        await store.setMeta('blocks', {
+          syncedAt: startedAt,
+          count: bw.blocks.length,
+          complete: true,
+        });
+      } else if (bw.error) {
+        errors.push(`blocks: ${bw.error}`);
       }
       if (ac.signal.aborted) return;
 
@@ -548,6 +574,7 @@ function useAnalyticsArchive(agent, did) {
 
 const PHASE_LABEL = {
   followers: 'Sweeping followers',
+  blocks: 'Reading block backlinks',
   repo: 'Downloading the repo',
   'repo-read': 'Reading the repo archive',
   posts: 'Archiving posts',
@@ -556,7 +583,7 @@ const PHASE_LABEL = {
 };
 
 function SyncStrip({ archive }) {
-  const { sync, syncError, meta, posts, followers, persistent, runSync, cancelSync } = archive;
+  const { sync, syncError, meta, posts, followers, blocks, persistent, runSync, cancelSync } = archive;
 
   if (sync) {
     const pct = sync.est ? Math.min(100, Math.round((sync.fetched / sync.est) * 100)) : null;
@@ -584,7 +611,8 @@ function SyncStrip({ archive }) {
     <div className="an-strip">
       <span className="an-strip-label">
         {posts.length.toLocaleString('en-US')} {posts.length === 1 ? 'post' : 'posts'} ·{' '}
-        {followers.length.toLocaleString('en-US')} {followers.length === 1 ? 'follower' : 'followers'}
+        {followers.length.toLocaleString('en-US')} {followers.length === 1 ? 'follower' : 'followers'} ·{' '}
+        {blocks.length.toLocaleString('en-US')} {blocks.length === 1 ? 'block' : 'blocks'}
         {pm.syncedAt ? ` · synced ${relativeTime(pm.syncedAt)}` : ''}
         {!pm.complete && ' · archive incomplete'}
         {!persistent && ' · this browser holds the archive for this session only'}
@@ -620,9 +648,10 @@ function FirstRun({ archive }) {
       <p className="an-hero-body">
         Analytics are derived client-side from your own data: the repo’s own archive (one download
         that yields every record in every collection, all-time), every current follower with the
-        date their follow record was minted, your recent notifications — and every post’s
-        engagement counts via the public AppView, which is the long part: a couple of hundred
-        requests, a minute or two, with the charts painting from the repo archive while it runs.
+        date their follow record was minted, every current block backlink dated from its TID, your
+        recent notifications — and every post’s engagement counts via the public AppView, which is
+        the long part: a couple of hundred requests, a minute or two, with the charts painting from
+        the repo archive while it runs.
         Everything lands in this browser’s IndexedDB; after the first build, syncs only top up
         what’s new.
         {!archive.persistent &&
@@ -760,6 +789,117 @@ function FollowersTab({ archive, period, nowMs }) {
         The curve dates each follower by their follow record — accounts that unfollowed are
         invisible to it.
         {model.undated > 0 && ` ${model.undated.toLocaleString('en-US')} followers carry no readable follow date and sit outside the chart.`}
+      </p>
+    </section>
+  );
+}
+
+/* ================================================================== */
+/* Blocks                                                               */
+/* ================================================================== */
+
+function BlocksTab({ archive, period, nowMs }) {
+  const { blocks } = archive;
+  const [mode, setMode] = useState('cumulative');
+
+  const model = useMemo(() => {
+    const dated = blocks
+      .map((block) => ({ ...block, atMs: Date.parse(block.blockedAt || '') }))
+      .filter((block) => Number.isFinite(block.atMs));
+    const undated = blocks.length - dated.length;
+    const oldest = dated.length ? Math.min(...dated.map((block) => block.atMs)) : nowMs;
+    const t0 = period.days ? nowMs - period.days * DAY_MS : oldest;
+    const spanDays = Math.max(1, Math.round((nowMs - t0) / DAY_MS));
+    const units = unitChoicesFor(period.days ? period.days : spanDays);
+    const unit = mode !== 'cumulative' && units.includes(mode) ? mode : defaultUnitFor(period.days ?? spanDays);
+    const inWindow = dated.filter((block) => block.atMs >= t0 && block.atMs <= nowMs);
+    const counts = bucketSeries(inWindow, {
+      unit,
+      t0,
+      t1: nowMs,
+      pickTime: (block) => block.atMs,
+    });
+    const baseline = dated.filter((block) => block.atMs < t0).length;
+    return {
+      total: blocks.length,
+      undated,
+      unit,
+      units,
+      counts,
+      cumulative: cumulativeSeries(counts, baseline),
+      received: inWindow.length,
+      perDay: inWindow.length / spanDays,
+      compare: comparePeriods(dated, {
+        days: period.days || spanDays,
+        now: nowMs,
+        pickTime: (block) => block.atMs,
+      }),
+    };
+  }, [blocks, period, mode, nowMs]);
+
+  if (!archive.meta.blocks) {
+    return <p className="an-empty">No block backlink sweep yet — run a sync to build this timeline.</p>;
+  }
+
+  const cumulative = mode === 'cumulative';
+  return (
+    <section className="an-panel" aria-label="Blocks received">
+      <div className="an-tiles">
+        <StatTile label="Current blocks" value={model.total} />
+        <StatTile
+          label={`New in ${period.label.toLowerCase()}`}
+          value={model.received}
+          delta={period.days ? model.compare.pct : null}
+          deltaTitle={
+            period.days
+              ? `vs previous ${period.label.toLowerCase()}: ${model.compare.previous.toLocaleString('en-US')}`
+              : null
+          }
+        />
+        <StatTile
+          label="Per day"
+          value={model.perDay < 10 ? Math.round(model.perDay * 10) / 10 : Math.round(model.perDay)}
+          exact
+        />
+      </div>
+
+      <div className="an-card">
+        <div className="an-card-head">
+          <h3 className="an-card-title">Blocks received</h3>
+          <ModeToggle
+            value={mode}
+            onChange={setMode}
+            options={[
+              { key: 'cumulative', label: 'Cumulative' },
+              ...model.units.map((unit) => ({ key: unit, label: unitLabel(unit) })),
+            ]}
+          />
+        </div>
+        <SeriesChart
+          series={cumulative ? model.cumulative : model.counts}
+          mode={cumulative ? 'line' : 'bars'}
+          unit={model.unit}
+          zeroBase={!cumulative}
+          ariaLabel={
+            cumulative
+              ? `Cumulative current blocks over ${period.label}`
+              : `New blocks per ${model.unit} over ${period.label}`
+          }
+        />
+        <ChartTable
+          series={cumulative ? model.cumulative : model.counts}
+          unit={model.unit}
+          valueHead={cumulative ? 'Current blocks' : 'New blocks'}
+        />
+      </div>
+
+      <p className="an-note">
+        Reconstructed from current <code>app.bsky.graph.block</code> backlinks indexed by
+        Constellation, dated by each block record&rsquo;s TID. Accounts that later remove their
+        block disappear on the next sync, so this is a timeline of blocks that still exist, not a
+        permanent record of every block ever created.
+        {model.undated > 0 &&
+          ` ${model.undated.toLocaleString('en-US')} blocks carry no readable TID and sit outside the chart.`}
       </p>
     </section>
   );

--- a/src/lib/analyticsStore.js
+++ b/src/lib/analyticsStore.js
@@ -15,14 +15,16 @@
 
 const DB_NAME = 'dame-analytics';
 // v2 added `atmosphere` — the whole-repo activity rows the CAR sync writes.
+// v3 added `blocks` — current block backlinks dated from their TID rkeys.
 // The upgrade path is the STORES loop in onupgradeneeded: any store missing
 // from an older database is created, nothing existing is touched.
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 
 /** store name → keyPath. One object store per archive, plus sync metadata. */
 const STORES = {
   posts: 'uri', // compact post rows (analytics.js compactPostFromFeedItem)
   followers: 'did', // { did, handle, displayName, avatar, followedAt }
+  blocks: 'uri', // { uri, did, blockedAt } — current Constellation block backlinks
   inbound: 'uri', // engagement events aimed at the owner
   outbound: 'uri', // the owner's like/repost events (replies/quotes derive from posts)
   atmosphere: 'uri', // { uri, collection, at } — every record on the repo, dated

--- a/src/lib/analyticsSync.js
+++ b/src/lib/analyticsSync.js
@@ -41,6 +41,7 @@
 import { APPVIEW } from '../config.js';
 import { rkeyFromAtUri, tidToTimestamp, resolveProfiles } from './atproto.js';
 import { compactPostFromFeedItem, inboundFromNotification, outboundFromRecord } from './analytics.js';
+import { backlinkRows, getBacklinks } from './constellation.js';
 
 /** Page size everywhere — the API maximum for all four endpoints. */
 const PAGE = 100;
@@ -51,7 +52,7 @@ const PAGE = 100;
  * this account's measured size; hitting one sets `truncated` rather than
  * lying by omission.
  */
-const CAPS = { followers: 200, posts: 500, inbound: 80, outboundPerKind: 120 };
+const CAPS = { followers: 200, blocks: 200, posts: 500, inbound: 80, outboundPerKind: 120 };
 
 /** One polite second ask, then the truth. Mirrors resolveProfiles' retry. */
 async function withRetry(fn, signal) {
@@ -115,6 +116,72 @@ export async function sweepFollowers(agent, did, { onProgress, signal } = {}) {
     }
   }
   return { followers, complete, aborted: false, error };
+}
+
+/* ------------------------------------------------------------------ */
+/* Blocks                                                               */
+/* ------------------------------------------------------------------ */
+
+const BLOCK_SOURCE = 'app.bsky.graph.block:subject';
+
+/**
+ * Sweep every current block record pointing at the owner through
+ * Constellation. Like follower records, block records use TID rkeys, so their
+ * keys provide an honest creation time without hydrating thousands of repos.
+ *
+ * Constellation indexes the current backlink set, not deleted records:
+ * unblocked accounts disappear on the next complete sweep.
+ *
+ * @returns {Promise<{blocks:Array, complete:boolean, truncated:boolean,
+ *                    aborted:boolean, error:string|null}>}
+ */
+export async function sweepBlocks(did, { onProgress, signal } = {}) {
+  const blocks = [];
+  const seen = new Set();
+  let cursor;
+
+  for (let pageNumber = 0; pageNumber < CAPS.blocks; pageNumber++) {
+    if (aborted(signal)) return result({ aborted: true });
+    const page = await getBacklinks(did, BLOCK_SOURCE, {
+      limit: PAGE,
+      cursor,
+      signal,
+    });
+    if (aborted(signal)) return result({ aborted: true });
+    if (!page) return result({ error: 'Constellation backlinks unavailable' });
+
+    for (const row of backlinkRows(page)) {
+      if (!row?.did || !row?.rkey) continue;
+      const uri = `at://${row.did}/${row.collection || 'app.bsky.graph.block'}/${row.rkey}`;
+      if (seen.has(uri)) continue;
+      seen.add(uri);
+      blocks.push({
+        uri,
+        did: row.did,
+        blockedAt: tidToTimestamp(row.rkey),
+      });
+    }
+    onProgress?.({ fetched: blocks.length });
+
+    const next = page.cursor || null;
+    if (!next || backlinkRows(page).length === 0) return result({ complete: true });
+    // A repeated cursor would otherwise spend the whole cap re-reading one
+    // page and call that a merely truncated history.
+    if (next === cursor) return result({ error: 'Constellation returned a repeated cursor' });
+    cursor = next;
+  }
+  return result({ truncated: true });
+
+  function result(flags = {}) {
+    return {
+      blocks,
+      complete: false,
+      truncated: false,
+      aborted: false,
+      error: null,
+      ...flags,
+    };
+  }
 }
 
 /* ------------------------------------------------------------------ */

--- a/src/lib/analyticsSync.test.js
+++ b/src/lib/analyticsSync.test.js
@@ -5,7 +5,7 @@
 // stopping logic with fake agents and a fake AppView.
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { sweepFollowers, sweepInbound, sweepOutbound, sweepPosts } from './analyticsSync.js';
+import { sweepBlocks, sweepFollowers, sweepInbound, sweepOutbound, sweepPosts } from './analyticsSync.js';
 import { tidToTimestamp } from './atproto.js';
 
 /** Mint a real TID for a timestamp — the same encoding tidToTimestamp reads. */
@@ -174,6 +174,56 @@ describe('sweepFollowers', () => {
     expect(Date.parse(res.followers[0].followedAt)).toBe(Date.parse(tidToTimestamp(tidFor(followedMs))));
     // No follow record visible → no invented date, but still a counted follower.
     expect(res.followers[1].followedAt).toBeNull();
+  });
+});
+
+describe('sweepBlocks', () => {
+  it('pages Constellation backlinks and dates block records from their TIDs', async () => {
+    const blockedMs = NOW - 4 * DAY;
+    const blockTid = tidFor(blockedMs);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url) => {
+        const parsed = new URL(url);
+        expect(parsed.searchParams.get('subject')).toBe('did:plc:me');
+        expect(parsed.searchParams.get('source')).toBe('app.bsky.graph.block:subject');
+        const cursor = parsed.searchParams.get('cursor');
+        return {
+          ok: true,
+          json: async () =>
+            cursor
+              ? { records: [], cursor: null }
+              : {
+                  records: [
+                    {
+                      did: 'did:plc:blocker',
+                      collection: 'app.bsky.graph.block',
+                      rkey: blockTid,
+                    },
+                  ],
+                  cursor: 'next',
+                },
+        };
+      }),
+    );
+
+    const res = await sweepBlocks('did:plc:me');
+    expect(res).toMatchObject({ complete: true, truncated: false, error: null });
+    expect(res.blocks).toHaveLength(1);
+    expect(res.blocks[0]).toMatchObject({
+      uri: `at://did:plc:blocker/app.bsky.graph.block/${blockTid}`,
+      did: 'did:plc:blocker',
+    });
+    expect(Date.parse(res.blocks[0].blockedAt)).toBe(
+      Date.parse(tidToTimestamp(blockTid)),
+    );
+  });
+
+  it('does not present a partial backlink sweep as complete', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 503 })));
+    const res = await sweepBlocks('did:plc:me');
+    expect(res.complete).toBe(false);
+    expect(res.error).toMatch(/unavailable/i);
   });
 });
 

--- a/src/lib/constellation.js
+++ b/src/lib/constellation.js
@@ -5,9 +5,9 @@
 
 const CONSTELLATION_BASE = 'https://constellation.microcosm.blue';
 
-async function fetchJsonOrNull(url) {
+async function fetchJsonOrNull(url, init) {
   try {
-    const res = await fetch(url);
+    const res = await fetch(url, init);
     if (!res.ok) return null;
     return await res.json();
   } catch {
@@ -49,7 +49,7 @@ export async function getBacklinkCount(target, source) {
  * `linking_records` on the older `/links` one — read them with
  * `backlinkRows()` rather than picking a field and hoping.
  */
-export async function getBacklinks(target, source, { limit = 25, cursor } = {}) {
+export async function getBacklinks(target, source, { limit = 25, cursor, signal } = {}) {
   if (!target || !source) return null;
   const params = new URLSearchParams({
     subject: target,
@@ -58,7 +58,7 @@ export async function getBacklinks(target, source, { limit = 25, cursor } = {}) 
   });
   if (cursor) params.set('cursor', cursor);
   const url = `${CONSTELLATION_BASE}/xrpc/blue.microcosm.links.getBacklinks?${params}`;
-  return fetchJsonOrNull(url);
+  return fetchJsonOrNull(url, signal ? { signal } : undefined);
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a Blocks tab to the admin analytics studio with the same date filters and cumulative/daily/weekly/monthly views as follower growth
- sweep current `app.bsky.graph.block:subject` backlinks from Constellation and date them from record-key TIDs
- persist block snapshots in the browser analytics archive and automatically populate existing archives
- document that removed blocks disappear from this reconstructed history

## Testing
- `npm test -- src/lib/analyticsSync.test.js src/lib/constellation.test.js src/lib/analytics.test.js` (48 passed)
- `npx eslint src/components/AnalyticsStudio.jsx src/lib/analyticsStore.js src/lib/analyticsSync.js src/lib/analyticsSync.test.js src/lib/constellation.js`
- `npm run build:offline`
- live Constellation sweep completed with 4,039 dated block records and no truncation

Full-repository lint still reports three pre-existing hook-rule errors in `PostCard.jsx` and `WebsiteBlockEditor.jsx`; the changed files pass lint.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86ed4e20-0675-406f-9848-00909b3a5a9f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86ed4e20-0675-406f-9848-00909b3a5a9f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

